### PR TITLE
Remove errors from Fern Definition

### DIFF
--- a/fern/api/definition/device.yml
+++ b/fern/api/definition/device.yml
@@ -27,9 +27,6 @@ services:
           response:
             type: Device
             docs: Returns the updated Device
-          errors:
-            - ids.AppNotFoundError
-            - ids.UserNotFoundError
 
         update:
           docs: Update a Device for a User.
@@ -49,10 +46,6 @@ services:
           response:
             type: Device
             docs: Returns the updated Device
-          errors:
-            - ids.AppNotFoundError
-            - ids.UserNotFoundError
-            - ids.DeviceNotFoundError
 
         deleteDevice:
           docs: Delete a Device for a User
@@ -68,10 +61,6 @@ services:
             device_id:
               type: ids.DeviceId
               docs: your device identifier
-          errors:
-            - ids.AppNotFoundError
-            - ids.UserNotFoundError
-            - ids.DeviceNotFoundError
 
         getDevice:
           docs: Get a Device for a User
@@ -88,9 +77,6 @@ services:
               type: ids.DeviceId
               docs: your device identifier
           response: Device
-          errors:
-            - ids.AppNotFoundError
-            - ids.DeviceNotFoundError
 
 types:
   Device:

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -28,9 +28,6 @@ services:
             app_id: ids.AppId
           request: SendEventRequest
           response: SendEventResponse
-          errors:
-            - EventNotFoundError
-            - EventNotPublishedError
 
         sendBulk:
           method: POST
@@ -39,9 +36,6 @@ services:
             app_id: ids.AppId
           request: BulkSendEventRequest
           response: SendEventResponse
-          errors:
-            - EventNotFoundError
-            - EventNotPublishedError
 
 types:
   SendEventRequest:
@@ -214,10 +208,3 @@ types:
         type: optional<User>
       override:
         type: optional<EventOverride>
-
-errors:
-  EventNotFoundError:
-    status-code: 404
-  EventNotPublishedError:
-    docs: Event must be published before it can be sent
-    status-code: 400

--- a/fern/api/definition/ids.yml
+++ b/fern/api/definition/ids.yml
@@ -3,11 +3,3 @@ types:
   UserId: string
   RequestId: string
   DeviceId: string
-
-errors:
-  AppNotFoundError:
-    status-code: 404
-  UserNotFoundError:
-    status-code: 404
-  DeviceNotFoundError:
-    status-code: 404

--- a/fern/api/definition/user.yml
+++ b/fern/api/definition/user.yml
@@ -21,8 +21,6 @@ services:
           response:
             type: RavenUser
             docs: Returns updated or newly created user.
-          errors:
-            - ids.AppNotFoundError
 
         get:
           docs: Gets the requested user
@@ -36,9 +34,6 @@ services:
               type: ids.UserId
               docs: your user identifier
           response: RavenUser
-          errors:
-            - ids.AppNotFoundError
-            - ids.UserNotFoundError
 
 types:
   CreateUserRequest: 


### PR DESCRIPTION
The Fern Definition includes `errors` for endpoints, which are only supported for internal API (where Fern is integrated on the backend). For now, I'm removing them from the definition.