### PR TITLE
upgrade ts sdk generator to 0.0.226

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -1,6 +1,6 @@
 release:
   - name: fernapi/fern-typescript-sdk
-    version: 0.0.224
+    version: 0.0.226
     publishing:
       npm:
         package-name: '@ravenapp/raven'


### PR DESCRIPTION
`0.0.226` fixes the publishing issue in raven-node:  https://github.com/ravenappdev/raven-node/actions/runs/3349260403/jobs/5549091893 