### PR TITLE
make postman secrets available in github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,7 @@ jobs:
           RAVEN_NPM_TOKEN: ${{ secrets.RAVEN_NPM_TOKEN }}
           RAVEN_MAVEN_USERNAME: ${{ secrets.RAVEN_MAVEN_USERNAME }}
           RAVEN_MAVEN_TOKEN: ${{ secrets.RAVEN_MAVEN_TOKEN }}
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          POSTMAN_WORKSPACE_ID: ${{ secrets.POSTMAN_WORKSPACE_ID }}
         run: fern release ${{ github.ref_name }} --log-level debug
         


### PR DESCRIPTION
The postman generator was failing because the postman secrets were not being made available to the `Release SDKs` GitHub workflow.