### PR TITLE
Remove wrapper types for aliases

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -9,7 +9,7 @@ release:
       repository: ravenappdev/raven-node
       
   - name: fernapi/fern-java-sdk
-    version: 0.0.123
+    version: 0.0.124
     publishing:
       maven:
         coordinate: dev.ravenapp:raven-java


### PR DESCRIPTION
By default, the java sdk generator would generate wrapper types for [aliases](https://github.com/ravenappdev/raven-api/blob/main/fern/api/definition/ids.yml#L4-L7).

Upgrading to version `0.0.124` won't generate the wrapper types. 