### PR TITLE
support environments in the java sdk

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -7,9 +7,8 @@ release:
         token: ${RAVEN_NPM_TOKEN}
     github:
       repository: ravenappdev/raven-node
-      
   - name: fernapi/fern-java-sdk
-    version: 0.0.124
+    version: 0.0.125
     publishing:
       maven:
         coordinate: dev.ravenapp:raven-java
@@ -17,12 +16,10 @@ release:
         password: ${RAVEN_MAVEN_TOKEN}
     github:
       repository: ravenappdev/raven-java
-      
   - name: fernapi/fern-openapi
     version: 0.0.10
     github:
       repository: ravenappdev/raven-openapi
-
   - name: fernapi/fern-postman
     version: 0.0.28
     publishing:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "raven",
-  "version": "0.0.229"
+  "version": "0.0.231"
 }


### PR DESCRIPTION
Today. consumers of the java sdk have to manually specify the url of the raven server. Version `0.0.125` of the java sdk generator will automatically generate the [default environment](https://github.com/ravenappdev/raven-api/blob/5358c57bb94309595ee05b70f1e112bdd350bacf/fern/api/definition/api.yml#L6-L8). 