### PR TITLE
🌿 propagate docs to Java SDK 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Download Fern
         run: npm install -g fern-api
 
-      - name: Release SDKs
+      - name: Release SDKs, OpenAPI Spec, Postman Collection
         env:
           RAVEN_NPM_TOKEN: ${{ secrets.RAVEN_NPM_TOKEN }}
           RAVEN_MAVEN_USERNAME: ${{ secrets.RAVEN_MAVEN_USERNAME }}
           RAVEN_MAVEN_TOKEN: ${{ secrets.RAVEN_MAVEN_TOKEN }}
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
           POSTMAN_WORKSPACE_ID: ${{ secrets.POSTMAN_WORKSPACE_ID }}
-        run: fern release ${{ github.ref_name }} --log-level debug
+        run: fern generate --group external --version ${{ github.ref_name }} --log-level debug
         

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -1,30 +1,32 @@
-release:
-  - name: fernapi/fern-typescript-sdk
-    version: 0.0.226
-    publishing:
-      npm:
-        package-name: '@ravenapp/raven'
-        token: ${RAVEN_NPM_TOKEN}
-    github:
-      repository: ravenappdev/raven-node
-  - name: fernapi/fern-java-sdk
-    version: 0.0.125
-    publishing:
-      maven:
-        coordinate: dev.ravenapp:raven-java
-        username: ${RAVEN_MAVEN_USERNAME}
-        password: ${RAVEN_MAVEN_TOKEN}
-    github:
-      repository: ravenappdev/raven-java
-  - name: fernapi/fern-openapi
-    version: 0.0.10
-    github:
-      repository: ravenappdev/raven-openapi
-  - name: fernapi/fern-postman
-    version: 0.0.28
-    publishing:
-      postman:
-        api-key: ${POSTMAN_API_KEY}
-        workspace-id: ${POSTMAN_WORKSPACE_ID}
-    github:
-      repository: ravenappdev/raven-postman
+groups:
+  external:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 0.0.241
+        output:
+          location: npm
+          package-name: '@ravenapp/raven'
+          token: ${RAVEN_NPM_TOKEN}
+        github:
+          repository: ravenappdev/raven-node
+      - name: fernapi/fern-java-sdk
+        version: 0.0.127
+        output:
+          location: maven
+          coordinate: dev.ravenapp:raven-java
+          username: ${RAVEN_MAVEN_USERNAME}
+          password: ${RAVEN_MAVEN_TOKEN}
+        github:
+          repository: ravenappdev/raven-java
+      - name: fernapi/fern-openapi
+        version: 0.0.11
+        github:
+          repository: ravenappdev/raven-openapi
+      - name: fernapi/fern-postman
+        version: 0.0.28
+        output:
+          location: postman
+          api-key: ${POSTMAN_API_KEY}
+          workspace-id: ${POSTMAN_WORKSPACE_ID}
+        github:
+          repository: ravenappdev/raven-postman

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "raven",
-  "version": "0.0.231"
+  "version": "0.0.246"
 }


### PR DESCRIPTION
In this PR: 
- Java Generator is upgraded to **0.0.127** to support propagating docs from the Fern Definition to the Java SDK. 
- Fern CLI is upgraded to **0.0.246**. In this upgrade, `fern release` is deprecated. Instead you can run `fern generate --group external --version <version>` which will invoke the generators in the [external group](https://github.com/ravenappdev/raven-api/blob/42e63d9a54f03eaffb0ba53a1ed054cc707c9445/fern/api/generators.yml#L2-L32).