### PR TITLE
Upgrade Fern to `0.3.5` for endpoint & type examples

### DIFF
--- a/fern/api/definition/api.yml
+++ b/fern/api/definition/api.yml
@@ -3,6 +3,8 @@ auth: AuthKey
 auth-schemes:
   AuthKey:
     header: Authorization
+error-discrimination:
+  strategy: status-code
 environments:
   Prod: https://api.ravenapp.dev
 default-environment: Prod

--- a/fern/api/definition/device.yml
+++ b/fern/api/definition/device.yml
@@ -23,7 +23,27 @@ services:
             user_id:
               type: ids.UserId
               docs: your user identifier
-          request: Device
+          request:
+            name: Device
+            body:
+              properties:
+                id: optional<string>
+                platform: optional<Platform>
+                onesignal_player_id: optional<string>
+                xiaomi_token: optional<string>
+                oppo_token: optional<string>
+                vivo_token: optional<string>
+                huaweiToken: optional<string>
+                fcm_token:
+                  type: optional<string>
+                  docs: firebase device token
+                raven_id:
+                  type: optional<string>
+                  docs: user id affiliated with device
+                device_sid: optional<ids.DeviceId>
+                notifications_disabled: optional<boolean>
+                created_at: optional<long>
+                updated_at: optional<long>
           response:
             type: Device
             docs: Returns the updated Device
@@ -42,7 +62,9 @@ services:
             device_id:
               type: ids.DeviceId
               docs: your device identifier; the same as device_sid
-          request: Device
+          request:
+            body:
+              type: Device
           response:
             type: Device
             docs: Returns the updated Device
@@ -79,26 +101,8 @@ services:
           response: Device
 
 types:
-  Device:
-    properties:
-      id: optional<string>
-      platform: optional<Platform>
-      onesignal_player_id: optional<string>
-      xiaomi_token: optional<string>
-      oppo_token: optional<string>
-      vivo_token: optional<string>
-      huaweiToken: optional<string>
-      fcm_token:
-        type: optional<string>
-        docs: firebase device token
-      raven_id:
-        type: optional<string>
-        docs: user id affiliated with device
-      device_sid: optional<ids.DeviceId>
-      notifications_disabled: optional<boolean>
-      created_at: optional<long>
-      updated_at: optional<long>
-
+  
+  
   Platform:
     enum:
       - android

--- a/fern/api/definition/device.yml
+++ b/fern/api/definition/device.yml
@@ -23,27 +23,7 @@ services:
             user_id:
               type: ids.UserId
               docs: your user identifier
-          request:
-            name: AddDeviceRequest
-            body:
-              properties:
-                id: optional<string>
-                platform: optional<Platform>
-                onesignal_player_id: optional<string>
-                xiaomi_token: optional<string>
-                oppo_token: optional<string>
-                vivo_token: optional<string>
-                huaweiToken: optional<string>
-                fcm_token:
-                  type: optional<string>
-                  docs: firebase device token
-                raven_id:
-                  type: optional<string>
-                  docs: user id affiliated with device
-                device_sid: optional<ids.DeviceId>
-                notifications_disabled: optional<boolean>
-                created_at: optional<long>
-                updated_at: optional<long>
+          request: Device 
           response:
             type: Device
             docs: Returns the updated Device

--- a/fern/api/definition/device.yml
+++ b/fern/api/definition/device.yml
@@ -23,7 +23,7 @@ services:
             user_id:
               type: ids.UserId
               docs: your user identifier
-          request: Device 
+          request: Device
           response:
             type: Device
             docs: Returns the updated Device
@@ -81,7 +81,7 @@ services:
           response: Device
 
 types:
-  Device: 
+  Device:
     properties:
       id: optional<string>
       platform: optional<Platform>
@@ -100,7 +100,7 @@ types:
       notifications_disabled: optional<boolean>
       created_at: optional<long>
       updated_at: optional<long>
-  
+
   Platform:
     enum:
       - android

--- a/fern/api/definition/device.yml
+++ b/fern/api/definition/device.yml
@@ -27,6 +27,17 @@ services:
           response:
             type: Device
             docs: Returns the updated Device
+          examples: 
+            - path-parameters:
+                app_id: my-app-id 
+                user_id: my-user-id 
+              request: 
+                fcm_token: qweKu7bdTZumJpzxUqqpxe:APA91bE9FSScPK_kENPpBAj0URYDo4z0tE6aOrBtpgaA1I1OC7GBes1lR71EWRhavLGMzDMKPPLkUoqtvPHzCgq
+                platform: android 
+              response: 
+                body: 
+                  id: my-device-id
+                  platform: android
 
         update:
           docs: Update a Device for a User.
@@ -48,6 +59,18 @@ services:
           response:
             type: Device
             docs: Returns the updated Device
+          examples:
+            - path-parameters:
+                app_id: my-app-id 
+                user_id: my-user-id 
+                device_id: my-device-id
+              request: 
+                fcm_token: qweKu7bdTZumJpzxUqqpxe:APA91bE9FSScPK_kENPpBAj0URYDo4z0tE6aOrBtpgaA1I1OC7GBes1lR71EWRhavLGMzDMKPPLkUoqtvPHzCgq
+                platform: android 
+              response: 
+                body: 
+                  id: my-device-id
+                  platform: android
 
         delete:
           docs: Delete a Device for a User

--- a/fern/api/definition/device.yml
+++ b/fern/api/definition/device.yml
@@ -24,7 +24,7 @@ services:
               type: ids.UserId
               docs: your user identifier
           request:
-            name: Device
+            name: AddDeviceRequest
             body:
               properties:
                 id: optional<string>
@@ -101,7 +101,25 @@ services:
           response: Device
 
 types:
-  
+  Device: 
+    properties:
+      id: optional<string>
+      platform: optional<Platform>
+      onesignal_player_id: optional<string>
+      xiaomi_token: optional<string>
+      oppo_token: optional<string>
+      vivo_token: optional<string>
+      huaweiToken: optional<string>
+      fcm_token:
+        type: optional<string>
+        docs: firebase device token
+      raven_id:
+        type: optional<string>
+        docs: user id affiliated with device
+      device_sid: optional<ids.DeviceId>
+      notifications_disabled: optional<boolean>
+      created_at: optional<long>
+      updated_at: optional<long>
   
   Platform:
     enum:

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -26,7 +26,30 @@ services:
           path: /{app_id}/events/send
           path-parameters:
             app_id: ids.AppId
-          request: SendEventRequest
+          request:
+            name: SendEventRequest
+            body:
+              properties:
+                event:
+                  type: string
+                  docs: event name
+                data:
+                  type: map<string, unknown>
+                  docs: |
+                    {
+                    "param1" : "<value1>",
+                    "param2" : "<value2>",
+                    "param3" : object/array"
+                    }
+                user:
+                  type: optional<User>
+                scheduleAt:
+                  type: optional<long>
+                  docs: |
+                    Time to send message expressed as UTC milliseconds. 
+                    If not present, message will be sent immediately.
+                override:
+                  type: optional<EventOverride>
           response: SendEventResponse
 
         sendBulk:
@@ -34,33 +57,18 @@ services:
           path: /{app_id}/events/bulk_send
           path-parameters:
             app_id: ids.AppId
-          request: BulkSendEventRequest
+          request:
+            name: BulkSendEventRequest
+            body:
+              properties:
+                event: string
+                batch:
+                  type: list<BatchEvent>
+                  docs: List of events
           response: SendEventResponse
 
 types:
-  SendEventRequest:
-    properties:
-      event:
-        type: string
-        docs: event name
-      data:
-        type: map<string, unknown>
-        docs: |
-          {
-          "param1" : "<value1>",
-          "param2" : "<value2>",
-          "param3" : object/array"
-          }
-      user:
-        type: optional<User>
-      scheduleAt:
-        type: optional<long>
-        docs: |
-          Time to send message expressed as UTC milliseconds. 
-          If not present, message will be sent immediately.
-      override:
-        type: optional<EventOverride>
-
+  
   User:
     properties:
       user_id:
@@ -198,13 +206,6 @@ types:
     properties:
       id: ids.RequestId
       success: boolean
-
-  BulkSendEventRequest:
-    properties:
-      event: string
-      batch:
-        type: list<BatchEvent>
-        docs: List of events
 
   BatchEvent:
     properties:

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -66,9 +66,18 @@ services:
             # error
             - path-parameters:
                 app_id: my_app_id
+              request:
+                event: sample_event_1
+                data:
+                  name: name
+                  date: 01 December 2022
+                user:
+                  mobile: "+919876543210"
+                  email: x@ravenapp.dev
+                  whatsapp_mobile: "+919876543210"
               response:
                 error: EventNotFoundError
-                body: 
+                body:
                   success: false
                   error: event not found
 
@@ -242,7 +251,7 @@ types:
         type: optional<EventOverride>
 
   EventNotFoundErrorBody:
-    properties: 
+    properties:
       success: boolean
       error: string
 

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -1,5 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
-
 imports:
   ids: ids.yml
   user: user.yml
@@ -25,14 +23,16 @@ services:
           method: POST
           path: /{app_id}/events/send
           path-parameters:
-            app_id: ids.AppId
+            app_id: 
+              type: ids.AppId
+              docs: The `id` of the app
           request:
             name: SendEventRequest
             body:
               properties:
                 event:
                   type: string
-                  docs: event name
+                  docs: The name of the event
                 data:
                   type: map<string, unknown>
                   docs: |
@@ -51,7 +51,22 @@ services:
                 override:
                   type: optional<EventOverride>
           response: SendEventResponse
-
+          examples: 
+            - path-parameters:
+                app_id: my_app_id
+              request: 
+                event: sample_event_1
+                data:
+                  name: name
+                  date: 01 December 2022
+                user: 
+                  mobile: "+919876543210"
+                  email: x@ravenapp.dev
+                  whatsapp_mobile: "+919876543210"
+              response:
+                body: 
+                  id: 1d1ed73c-96e6-4aa3-abc2-2e9a926f773a 
+                  success: true
         sendBulk:
           method: POST
           path: /{app_id}/events/bulk_send
@@ -68,14 +83,13 @@ services:
           response: SendEventResponse
 
 types:
-  
   User:
     properties:
       user_id:
         type: optional<ids.UserId>
         docs: |
           userId to send the notifications to. 
-          This is  your own user identifier which you have used to create user on Raven
+          This is  your own user identifier which you have used to [create user on Raven](https://docs.raven.dev/api-reference/create-user)
       email:
         type: optional<string>
       mobile:
@@ -88,8 +102,8 @@ types:
           if empty, `mobile` is considered for whatsapp
       onesignal_external_id:
         type: optional<string>
-        docs: "[OneSignal external user
-          IDs](https://documentation.onesignal.com/docs/external-user-ids)"
+        docs: | 
+          [OneSignal external user IDs](https://documentation.onesignal.com/docs/external-user-ids)
       onesignal_player_ids:
         type: optional<list<string>>
       fcm_tokens:

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
 imports:
   ids: ids.yml
   user: user.yml
@@ -95,6 +97,32 @@ services:
                   type: list<BatchEvent>
                   docs: List of events
           response: SendEventResponse
+          examples: 
+            - path-parameters:
+                app_id: my-app-id 
+              request: 
+                event: sample_event_1
+                batch: 
+                  - user: 
+                      mobile: "+919876543210"
+                      email: x@ravenapp.dev
+                      whatsapp_mobile: "+919876543210"
+                    data: 
+                      name: John Doe 
+                      date: 01 December 2022
+                  - user: 
+                      mobile: "+919876543210"
+                      email: x@ravenapp.dev
+                      whatsapp_mobile: "+919876543210"
+                    data: 
+                      name: John Doe 
+                      date: 01 December 2022
+              response:
+                body:
+                  id: 1d1ed73c-96e6-4aa3-abc2-2e9a926f773a
+                  success: true
+                
+
 
 types:
   User:

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -33,14 +33,7 @@ services:
                 event:
                   type: string
                   docs: The name of the event
-                data:
-                  type: map<string, unknown>
-                  docs: |
-                    {
-                    "param1" : "<value1>",
-                    "param2" : "<value2>",
-                    "param3" : object/array"
-                    }
+                data: map<string, unknown>
                 user:
                   type: optional<User>
                 scheduleAt:

--- a/fern/api/definition/event.yml
+++ b/fern/api/definition/event.yml
@@ -23,7 +23,7 @@ services:
           method: POST
           path: /{app_id}/events/send
           path-parameters:
-            app_id: 
+            app_id:
               type: ids.AppId
               docs: The `id` of the app
           request:
@@ -44,22 +44,34 @@ services:
                 override:
                   type: optional<EventOverride>
           response: SendEventResponse
-          examples: 
+          errors:
+            - EventNotFoundError
+          examples:
+            # success
             - path-parameters:
                 app_id: my_app_id
-              request: 
+              request:
                 event: sample_event_1
                 data:
                   name: name
                   date: 01 December 2022
-                user: 
+                user:
                   mobile: "+919876543210"
                   email: x@ravenapp.dev
                   whatsapp_mobile: "+919876543210"
               response:
-                body: 
-                  id: 1d1ed73c-96e6-4aa3-abc2-2e9a926f773a 
+                body:
+                  id: 1d1ed73c-96e6-4aa3-abc2-2e9a926f773a
                   success: true
+            # error
+            - path-parameters:
+                app_id: my_app_id
+              response:
+                error: EventNotFoundError
+                body: 
+                  success: false
+                  error: event not found
+
         sendBulk:
           method: POST
           path: /{app_id}/events/bulk_send
@@ -95,7 +107,7 @@ types:
           if empty, `mobile` is considered for whatsapp
       onesignal_external_id:
         type: optional<string>
-        docs: | 
+        docs: |
           [OneSignal external user IDs](https://documentation.onesignal.com/docs/external-user-ids)
       onesignal_player_ids:
         type: optional<list<string>>
@@ -228,3 +240,13 @@ types:
         type: optional<User>
       override:
         type: optional<EventOverride>
+
+  EventNotFoundErrorBody:
+    properties: 
+      success: boolean
+      error: string
+
+errors:
+  EventNotFoundError:
+    status-code: 404
+    type: EventNotFoundErrorBody

--- a/fern/api/definition/user.yml
+++ b/fern/api/definition/user.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
 imports:
   ids: ids.yml
   device: device.yml

--- a/fern/api/definition/user.yml
+++ b/fern/api/definition/user.yml
@@ -16,7 +16,21 @@ services:
           path: /{app_id}/users
           path-parameters:
             app_id: ids.AppId
-          request: CreateUserRequest
+          request:
+            name: CreateUserRequest
+            body:
+              properties:
+                user_id:
+                  type: ids.UserId
+                  docs: |
+                    Your user identifier. 
+                      if user_id already exists, user properties will be updated else a new user will be created
+                mobile: optional<string>
+                email: optional<string>
+                whats_app:
+                  type: optional<string>
+                  docs: include this only when user's whatsapp mobile is different than primary
+                    mobile
           response:
             type: RavenUser
             docs: Returns updated or newly created user.
@@ -35,19 +49,7 @@ services:
           response: RavenUser
 
 types:
-  CreateUserRequest:
-    properties:
-      user_id:
-        type: ids.UserId
-        docs: |
-          Your user identifier. 
-            if user_id already exists, user properties will be updated else a new user will be created
-      mobile: optional<string>
-      email: optional<string>
-      whats_app:
-        type: optional<string>
-        docs: include this only when user's whatsapp mobile is different than primary mobile
-
+  
   RavenUser:
     properties:
       user_id:
@@ -63,7 +65,8 @@ types:
         type: optional<string>
       whatsapp_mobile:
         type: optional<string>
-        docs: Include this only when user's whatsapp mobile is different than primary mobile
+        docs: Include this only when user's whatsapp mobile is different than primary
+          mobile
       slack: optional<SlackProfile>
       telegram: optional<TelegramProfile>
       fcm_tokens: optional<list<string>>

--- a/fern/api/definition/user.yml
+++ b/fern/api/definition/user.yml
@@ -49,7 +49,7 @@ services:
           response: RavenUser
 
 types:
-  
+
   RavenUser:
     properties:
       user_id:

--- a/fern/api/definition/user.yml
+++ b/fern/api/definition/user.yml
@@ -1,5 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
-
 imports:
   ids: ids.yml
   device: device.yml
@@ -34,6 +32,21 @@ services:
           response:
             type: RavenUser
             docs: Returns updated or newly created user.
+          examples: 
+            - path-parameters:
+                app_id: my-app-id 
+              request: 
+                user_id: test-user
+                mobile: "9876543210"
+                email: x@ravenapp.dev
+              response: 
+                body: 
+                  user_id: test-user
+                  slack:
+                    access_token: my-access-token
+                    email: x@ravenapp.dev
+                    channel_id: channel-123
+          
 
         get:
           docs: Gets the requested user
@@ -47,6 +60,18 @@ services:
               type: ids.UserId
               docs: your user identifier
           response: RavenUser
+          examples: 
+            - path-parameters:
+                app_id: my-app-id 
+                user_id: my-user-id 
+              response: 
+                body: 
+                  user_id: my-user-id
+                  slack:
+                    access_token: my-access-token
+                    email: x@ravenapp.dev
+                    channel_id: channel-123
+            
 
 types:
 

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.0.249
+        version: 0.0.251
         output:
           location: npm
           package-name: '@ravenapp/raven'
@@ -23,7 +23,7 @@ groups:
         github:
           repository: ravenappdev/raven-openapi
       - name: fernapi/fern-postman
-        version: 0.0.32-rc0
+        version: 0.0.32
         output:
           location: postman
           api-key: ${POSTMAN_API_KEY}

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.0.241
+        version: 0.0.249
         output:
           location: npm
           package-name: '@ravenapp/raven'

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -19,11 +19,11 @@ groups:
         github:
           repository: ravenappdev/raven-java
       - name: fernapi/fern-openapi
-        version: 0.0.11
+        version: 0.0.11-4-g1c29f6c
         github:
           repository: ravenappdev/raven-openapi
       - name: fernapi/fern-postman
-        version: 0.0.28
+        version: 0.0.32-rc0
         output:
           location: postman
           api-key: ${POSTMAN_API_KEY}

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "raven",
-  "version": "0.3.0-rc14"
+  "version": "0.3.5"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "raven",
-  "version": "0.3.0-rc12"
+  "version": "0.3.0-rc14"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "raven",
-  "version": "0.0.246"
+  "version": "0.3.0-rc12"
 }


### PR DESCRIPTION
In this PR:

- Fern is upgraded to `0.3.5` to support examples in the Raven API definition
- TypeScript SDK version is upgraded to `0.0.251` to support type examples
- Added request & response examples as available in your API docs today

After merging this PR:

- We'll release a new version of the API. This will update the OpenAPI spec and Postman Collection with examples.
- To see what a Postman Collection with examples looks like, checkout [Mirror World](https://www.postman.com/fern-api/workspace/fern-mirrorworld/example/21510182-56d6a9cd-e522-455d-941f-c14bfada5d5c).
- You can chat with @Mintlify about syncing your reference docs from Fern.