### PR TITLE
Add FERN_TOKEN to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,6 @@ jobs:
           RAVEN_MAVEN_TOKEN: ${{ secrets.RAVEN_MAVEN_TOKEN }}
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
           POSTMAN_WORKSPACE_ID: ${{ secrets.POSTMAN_WORKSPACE_ID }}
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: fern generate --group external --version ${{ github.ref_name }} --log-level debug
         


### PR DESCRIPTION
This PR adds `FERN_TOKEN` to the workflow that runs `fern generate`. In future versions of fern, this token will be required for `generate`.

**Action required:** Please add the `FERN_TOKEN` to your Github secrets so this comes through! Reach out on Slack if you don't have a token saved and we can generate a new one for you.