### PR TITLE
Add root API endpoints using __package__.yml

### DIFF
--- a/fern/api/definition/__package__.yml
+++ b/fern/api/definition/__package__.yml
@@ -26,7 +26,30 @@ services:
           path: /{app_id}/events/send
           path-parameters:
             app_id: ids.AppId
-          request: SendEventRequest
+          request:
+            name: SendEventRequest
+            body:
+              properties:
+                event:
+                  type: string
+                  docs: event name
+                data:
+                  type: map<string, unknown>
+                  docs: |
+                    {
+                    "param1" : "<value1>",
+                    "param2" : "<value2>",
+                    "param3" : object/array"
+                    }
+                user:
+                  type: optional<User>
+                scheduleAt:
+                  type: optional<long>
+                  docs: |
+                    Time to send message expressed as UTC milliseconds. 
+                    If not present, message will be sent immediately.
+                override:
+                  type: optional<EventOverride>
           response: SendEventResponse
 
         sendBulk:
@@ -34,32 +57,17 @@ services:
           path: /{app_id}/events/bulk_send
           path-parameters:
             app_id: ids.AppId
-          request: BulkSendEventRequest
+          request:
+            name: BulkSendEventRequest
+            body:
+              properties:
+                event: string
+                batch:
+                  type: list<BatchEvent>
+                  docs: List of events
           response: SendEventResponse
 
 types:
-  SendEventRequest:
-    properties:
-      event:
-        type: string
-        docs: event name
-      data:
-        type: map<string, unknown>
-        docs: |
-          {
-          "param1" : "<value1>",
-          "param2" : "<value2>",
-          "param3" : object/array"
-          }
-      user:
-        type: optional<User>
-      scheduleAt:
-        type: optional<long>
-        docs: |
-          Time to send message expressed as UTC milliseconds. 
-          If not present, message will be sent immediately.
-      override:
-        type: optional<EventOverride>
 
   User:
     properties:
@@ -198,13 +206,6 @@ types:
     properties:
       id: ids.RequestId
       success: boolean
-
-  BulkSendEventRequest:
-    properties:
-      event: string
-      batch:
-        type: list<BatchEvent>
-        docs: List of events
 
   BatchEvent:
     properties:

--- a/fern/api/definition/user.yml
+++ b/fern/api/definition/user.yml
@@ -16,7 +16,21 @@ services:
           path: /{app_id}/users
           path-parameters:
             app_id: ids.AppId
-          request: CreateUserRequest
+          request:
+            name: CreateUserRequest
+            body:
+              properties:
+                user_id:
+                  type: ids.UserId
+                  docs: |
+                    Your user identifier. 
+                      if user_id already exists, user properties will be updated else a new user will be created
+                mobile: optional<string>
+                email: optional<string>
+                whats_app:
+                  type: optional<string>
+                  docs: include this only when user's whatsapp mobile is different than primary
+                    mobile
           response:
             type: RavenUser
             docs: Returns updated or newly created user.
@@ -35,18 +49,6 @@ services:
           response: RavenUser
 
 types:
-  CreateUserRequest:
-    properties:
-      user_id:
-        type: ids.UserId
-        docs: |
-          Your user identifier. 
-            if user_id already exists, user properties will be updated else a new user will be created
-      mobile: optional<string>
-      email: optional<string>
-      whats_app:
-        type: optional<string>
-        docs: include this only when user's whatsapp mobile is different than primary mobile
 
   RavenUser:
     properties:
@@ -63,7 +65,8 @@ types:
         type: optional<string>
       whatsapp_mobile:
         type: optional<string>
-        docs: Include this only when user's whatsapp mobile is different than primary mobile
+        docs: Include this only when user's whatsapp mobile is different than primary
+          mobile
       slack: optional<SlackProfile>
       telegram: optional<TelegramProfile>
       fcm_tokens: optional<list<string>>

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "raven",
-  "version": "0.0.246"
+  "version": "0.3.11"
 }


### PR DESCRIPTION
This PR:
1. Upgrades fern to the latest version
1. Utilizes the new `__package__.yml` special file. In this file, you can specify package-level endpoints. In the generated SDKs, these translate to methods in the root client (e.g. `client.send` rather than `client.event.send`)